### PR TITLE
added .dvmrc version lock support

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,6 +104,19 @@ $ dvm upgrade # upgrade to latest
 $ dvm upgrade v0.2.0 # Update to specified version
 ```
 
+### .dvmrc
+
+You can use `.dvmrc` file to lock your deno project to a specific version
+
+When you run the `dvm use` command, dvm will pick your deno version
+
+```bash
+# .dvmrc
+v1.0.0 # this can be 1.0.0 as well
+
+$ dvm use
+```
+
 ### Uninstall
 
 run the following command to uninstall `dvm` or remove `dvm` executable file and `$HOME/.dvm` folder by manual

--- a/internal/command/use.go
+++ b/internal/command/use.go
@@ -6,6 +6,7 @@ import (
 	"os"
 	"path"
 	"runtime"
+	"strings"
 
 	"github.com/axetroy/dvm/internal/core"
 	"github.com/axetroy/dvm/internal/fs"
@@ -15,6 +16,16 @@ import (
 
 // use Deno
 func Use(version string) error {
+	if version == "" {
+		data, _ := ioutil.ReadFile(".dvmrc")
+
+		if data == nil {
+			return errors.New(fmt.Sprintf("No .dvmrc file found \n\nrequire argument <%s>", "version"))
+		} else {
+			version = setCharV(strings.TrimSpace(string(data)))
+		}
+	}
+
 	files, err := ioutil.ReadDir(core.ReleaseDir)
 
 	if err != nil {
@@ -60,4 +71,12 @@ func Use(version string) error {
 	fmt.Printf("Currently using Deno %s\n", version)
 
 	return nil
+}
+
+func setCharV(version string) string {
+	if string(version[0]) != "v" {
+		return "v" + string(version)
+	}
+
+	return string(version)
 }

--- a/main.go
+++ b/main.go
@@ -106,10 +106,12 @@ SOURCE CODE:
 			Usage:     "Use specified Deno version",
 			ArgsUsage: "<version>",
 			Action: func(c *cli.Context) error {
-				if c.Args().Len() == 0 {
-					return errors.New(fmt.Sprintf("require argument <%s>", "version"))
+				var version string
+
+				if c.Args().Len() != 0 {
+					version = c.Args().First()
 				}
-				return command.Use(c.Args().First())
+				return command.Use(version)
 			},
 		},
 		{


### PR DESCRIPTION
# Story
This PR Incudes,

- added `.dvmrc` file for deno version lock. this will automatically pick deno version from `.dvmrc` when run `dvm use`
- updated the readme file with usage